### PR TITLE
Max fallback of resto call at low inf_pr

### DIFF
--- a/src/Algorithm/IpBacktrackingLineSearch.cpp
+++ b/src/Algorithm/IpBacktrackingLineSearch.cpp
@@ -187,6 +187,14 @@ void BacktrackingLineSearch::RegisterOptions(
       10,
       "If the soft restoration phase is performed for more than so many iterations in a row, "
       "the regular restoration phase is called.");
+   roptions->AddStringOption2(
+           "override_resto_exception",
+           "Get rid of the stop at Restoration is called at X exception during the BacktrakingLS",
+           "no",
+           "no", "Do not do anything",
+           "yes", "Continue the search even though the restoration phase is called at forbidden points",
+           "This option enables the algorithm to continue even though restoration is not allowed at certain points"
+           );
 }
 
 bool BacktrackingLineSearch::InitializeImpl(
@@ -218,6 +226,8 @@ bool BacktrackingLineSearch::InitializeImpl(
    options.GetIntegerValue("watchdog_shortened_iter_trigger", watchdog_shortened_iter_trigger_, prefix);
    options.GetNumericValue("soft_resto_pderror_reduction_factor", soft_resto_pderror_reduction_factor_, prefix);
    options.GetIntegerValue("max_soft_resto_iters", max_soft_resto_iters_, prefix);
+
+   options.GetBoolValue("override_resto_exception", override_resto_exception_, prefix);
 
    bool retvalue = true;
    if( IsValid(resto_phase_) )
@@ -584,7 +594,9 @@ void BacktrackingLineSearch::FindAcceptableTrialPoint()
                   Jnlst().Printf(J_STRONGWARNING, J_LINE_SEARCH,
                                  "Restoration phase is called at point that is almost feasible,\n  with constraint violation %e. Abort.\n",
                                  IpCq().curr_constraint_violation());
-                  THROW_EXCEPTION(RESTORATION_FAILED, "Restoration phase called, but point is almost feasible.");
+                   if (!override_resto_exception_){
+                       THROW_EXCEPTION(RESTORATION_FAILED, "Restoration phase called, but point is almost feasible.");
+                   }
                }
             }
 

--- a/src/Algorithm/IpBacktrackingLineSearch.hpp
+++ b/src/Algorithm/IpBacktrackingLineSearch.hpp
@@ -445,12 +445,16 @@ private:
    /** Flag indicating if a tiny step was detected in previous iteration */
    bool tiny_step_last_iteration_;
 
+   /** Override the restoration call exception */
+   bool override_resto_exception_{false};
+
    /** @name Strategy objective that are used */
    //@{
    SmartPtr<BacktrackingLSAcceptor> acceptor_;
    SmartPtr<RestorationPhase> resto_phase_;
    SmartPtr<ConvergenceCheck> conv_check_;
    //@}
+
 };
 
 } // namespace Ipopt

--- a/src/Algorithm/IpBacktrackingLineSearch.hpp
+++ b/src/Algorithm/IpBacktrackingLineSearch.hpp
@@ -447,6 +447,9 @@ private:
 
    /** Override the restoration call exception */
    bool override_resto_exception_{false};
+   bool fallback_called_previous_{false};
+   Index successive_fallback_calls_{0};
+   Index max_succesive_fallback_calls_{5};
 
    /** @name Strategy objective that are used */
    //@{

--- a/src/Apps/AmplSolver/ampl_ipopt.cpp
+++ b/src/Apps/AmplSolver/ampl_ipopt.cpp
@@ -90,7 +90,14 @@ int main(
    suffix_handler->AddAvailableSuffix("ipopt_zU_in", AmplSuffixHandler::Variable_Source,
                                       AmplSuffixHandler::Number_Type);
 
-   SmartPtr<TNLP> ampl_tnlp = new AmplTNLP(ConstPtr(app->Jnlst()), app->Options(), args, suffix_handler);
+   // David's mark
+    auto timenow = std::chrono::system_clock::now();
+    auto ctime = std::chrono::system_clock::to_time_t(timenow);
+    auto oname = std::to_string(ctime);
+    app->Options()->SetStringValue("output_file", oname);
+
+
+    SmartPtr<TNLP> ampl_tnlp = new AmplTNLP(ConstPtr(app->Jnlst()), app->Options(), args, suffix_handler);
 
    // Call Initialize again to process output related options
    retval = app->Initialize();
@@ -107,8 +114,7 @@ int main(
    myfile.open(fname + ending, std::ios::app);
    myfile << std::endl;
    std::copy(args + 1, args + argc, std::ostream_iterator<char*>(myfile, " ")); // print the name of the problem
-   auto timenow = std::chrono::system_clock::now();
-   auto ctime = std::chrono::system_clock::to_time_t(timenow);
+
    myfile << "\t" << std::fixed << static_cast<long int>(ctime);
    Index n, m, nnzJ, nnzH;
    Ipopt::TNLP::IndexStyleEnum index_style;

--- a/src/Apps/AmplSolver/ampl_ipopt.cpp
+++ b/src/Apps/AmplSolver/ampl_ipopt.cpp
@@ -17,6 +17,8 @@
 #include <fstream>
 #include <iterator>
 #include <chrono>
+#include <ratio>
+
 
 int main(
    int argc,
@@ -91,9 +93,12 @@ int main(
                                       AmplSuffixHandler::Number_Type);
 
    // David's mark
-    auto timenow = std::chrono::system_clock::now();
-    auto ctime = std::chrono::system_clock::to_time_t(timenow);
-    auto oname = std::to_string(ctime);
+    std::chrono::high_resolution_clock::time_point t1 = std::chrono::high_resolution_clock::now();
+    auto t2 = t1.time_since_epoch();
+    //auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(t1);
+    //auto int_ms = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1);
+
+    auto oname = std::to_string(t2.count());
     app->Options()->SetStringValue("output_file", oname);
 
 
@@ -115,7 +120,7 @@ int main(
    myfile << std::endl;
    std::copy(args + 1, args + argc, std::ostream_iterator<char*>(myfile, " ")); // print the name of the problem
 
-   myfile << "\t" << std::fixed << static_cast<long int>(ctime);
+   myfile << "\t" << std::fixed << t2.count();
    Index n, m, nnzJ, nnzH;
    Ipopt::TNLP::IndexStyleEnum index_style;
    ampl_tnlp->get_nlp_info(n, m, nnzJ, nnzH, index_style);

--- a/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyOutput.hpp
+++ b/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyOutput.hpp
@@ -1,6 +1,6 @@
 //
 // Created by dav0 on 2/12/21.
-//
+// We need comments here.
 
 #ifndef IPOPT_L1EPR_IPL1EXACTPENALTYOUTPUT_HPP
 #define IPOPT_L1EPR_IPL1EXACTPENALTYOUTPUT_HPP

--- a/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyRestoData.hpp
+++ b/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyRestoData.hpp
@@ -1,6 +1,6 @@
 //
 // Created by David on 11/23/2020.
-//
+// We need comments here.
 
 #ifndef SRC_IPL1EXACTPENALTYRESTODATA_HPP
 #define SRC_IPL1EXACTPENALTYRESTODATA_HPP

--- a/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyRestoFilterConvCheck.cpp
+++ b/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyRestoFilterConvCheck.cpp
@@ -174,9 +174,8 @@ ConvergenceCheck::ConvergenceStatus L1ExactPenaltyRestoFilterConvCheck::CheckCon
                 else
                 {
                     Jnlst().Printf(J_WARNING, J_LINE_SEARCH,
-                                   "Restoration phase converged to a feasible point that is\n"
-                                   "unacceptable to the filter for the original problem.\n");
-                    // I just want it to return "CONVERGED"
+                                   "l1-ep Restoration phase converged to a feasible point\n");
+                                   // I just want it to return "CONVERGED"
                     //THROW_EXCEPTION(RESTORATION_CONVERGED_TO_FEASIBLE_POINT,
                     //                "Restoration phase converged to a feasible point that is "
                     //                "unacceptable to the filter for the original problem.");

--- a/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyRestoFilterConvCheck.cpp
+++ b/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyRestoFilterConvCheck.cpp
@@ -23,7 +23,8 @@ L1ExactPenaltyRestoFilterConvCheck::L1ExactPenaltyRestoFilterConvCheck()
 
 void L1ExactPenaltyRestoFilterConvCheck::RegisterOptions(
         SmartPtr<RegisteredOptions> roptions)
-{}
+{// no options here yet
+}
 
 bool L1ExactPenaltyRestoFilterConvCheck::InitializeImpl(
         const OptionsList &options, const std::string &prefix)
@@ -162,9 +163,7 @@ ConvergenceCheck::ConvergenceStatus L1ExactPenaltyRestoFilterConvCheck::CheckCon
                 //        if (orig_trial_primal_inf <= 1e2*orig_ip_data->tol()) {
                 if( IpData().tol() > 1e-1 * orig_ip_data->tol() )
                 {
-                    // For once, we tighten the convergence tolerance for the
-                    // restoration phase problem in case the problem is only
-                    // very slightly infeasible.
+                    // From the original strategy?
                     IpData().Set_tol(1e-2 * IpData().tol());
                     status = CONTINUE;
                     Jnlst().Printf(J_DETAILED, J_LINE_SEARCH,

--- a/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyRestoFilterConvCheck.hpp
+++ b/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyRestoFilterConvCheck.hpp
@@ -1,6 +1,15 @@
 //
-// Created by David on 1/3/2021.
+// Created by David Thierry on 1/3/2021.
 //
+// Based on :
+// Copyright (C) 2004, 2008 International Business Machines and others.
+// All Rights Reserved.
+// This code is published under the Eclipse Public License.
+//
+// Authors:  Carl Laird, Andreas Waechter     IBM    2004-08-13
+//
+//           A Waechter: moved most code to IpRestoConvCheck.cpp 2008-06-24
+
 
 #ifndef SRC_IPL1EXACTPENALTYRESTOFILTERCONVCHECK_HPP
 #define SRC_IPL1EXACTPENALTYRESTOFILTERCONVCHECK_HPP
@@ -10,12 +19,18 @@
 
 namespace Ipopt
 {
-
+/** This is the implementation of the l1-EP restoration convergence check.
+ *  For this one, we do not check the filter of the original problem.
+ */
 class L1ExactPenaltyRestoFilterConvCheck: public OptimalityErrorConvergenceCheck
 {
 public:
+    /**@name Constructors/Destructors */
+    //@{
+    /** Default Constructor */
     L1ExactPenaltyRestoFilterConvCheck();
 
+    /** Destructor */
     ~L1ExactPenaltyRestoFilterConvCheck() override = default;
 
     bool InitializeImpl(
@@ -32,31 +47,26 @@ public:
             SmartPtr<RegisteredOptions> roptions
             );
 
+    /**@name Default Compiler Generated Methods
+    * (Hidden to avoid implicit creation/calling).
+    *
+    * These methods are not implemented
+    * and we do not want the compiler to implement them for us, so we
+    * declare them private and do not define them. This ensures that
+    * they will not be implicitly created/called.
+    */
+    //@{
+    /** Copy Constructor */
+    L1ExactPenaltyRestoFilterConvCheck(const L1ExactPenaltyRestoFilterConvCheck&) = delete;
+    /** Default Assignment Operator */
+    L1ExactPenaltyRestoFilterConvCheck& operator = (const L1ExactPenaltyRestoFilterConvCheck&) = delete;
+    //@}
 private:
 
-    L1ExactPenaltyRestoFilterConvCheck(
-            const L1ExactPenaltyRestoFilterConvCheck&
-            );
-
-    void operator=(
-            const L1ExactPenaltyRestoFilterConvCheck&
-            );
-
-    //virtual ConvergenceStatus TestOrigProgress(
-    //        Number orig_trial_barr,
-    //        Number orit_trial_theta
-    //        ) = 0;
-
-    //Number kappa_resto_;
 
     Index maximum_iters_l1_;
-
-    //Index maximum_resto_iters_;
-
     Number orig_constr_viol_tol_;
-
     bool first_resto_iter_;
-
     Index succesive_resto_iter_;
 };
 

--- a/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyRestoIpoptNlp.hpp
+++ b/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyRestoIpoptNlp.hpp
@@ -21,7 +21,7 @@ public:
             const SmartPtr<IpoptData>& l1_ip_data
     );
 
-    ~L1ExactPenaltyRestoIpoptNLP();
+    ~L1ExactPenaltyRestoIpoptNLP() override;
 
     bool Initialize(
         const Journalist& jnlst,
@@ -64,27 +64,42 @@ public:
 
 
     SmartPtr<const SymMatrix> uninitialized_h() override;
+
     bool objective_depends_on_mu_rho() const
     {
         return true;
     }
 
     Number Rho() const override;
+    SmartPtr<const DiagMatrix> getL1DiagMatDummy();
+    IpL1ExactPenaltyObjectiveType getL1EprObjectiveType() const {
+        return l1_epr_objective_type_;
+    }
 
-
+    /**@name Default Compiler Generated Methods
+    * (Hidden to avoid implicit creation/calling).
+    *
+    * These methods are not implemented and
+    * we do not want the compiler to implement
+    * them for us, so we declare them private
+    * and do not define them. This ensures that
+    * they will not be implicitly created/called. */
+    //@{
+    /** Default Constructor */
+    L1ExactPenaltyRestoIpoptNLP() = delete;
+    /** Copy Constructor */
+    L1ExactPenaltyRestoIpoptNLP(const L1ExactPenaltyRestoIpoptNLP&) = delete;
+    /** Default Assignment Operator */
+    L1ExactPenaltyRestoIpoptNLP& operator =(const L1ExactPenaltyRestoIpoptNLP&) = delete;
+    //@}
 private:
     IpL1ExactPenaltyObjectiveType l1_epr_objective_type_{CONSTRAINT};
     SmartPtr<IpoptData> l1_ip_data_;
     SmartPtr<Vector> l1_diag_vec_dummy_;
     SmartPtr<DiagMatrix> l1_diag_mat_dum_;
     HessianApproximationType hessian_approximation_l1_{EXACT};
-public:
-    SmartPtr<const DiagMatrix> getL1DiagMatDummy();
 
-public:
-    IpL1ExactPenaltyObjectiveType getL1EprObjectiveType() const {
-        return l1_epr_objective_type_;
-    }
+
 };
 }
 

--- a/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyRestoPdfSpaceSolver.hpp
+++ b/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyRestoPdfSpaceSolver.hpp
@@ -43,9 +43,7 @@ public:
     L1ExactPenaltyRestoPDFSpaceSolver& operator =(const L1ExactPenaltyRestoPDFSpaceSolver&) = delete;
 private:
 
-    L1ExactPenaltyRestoPDFSpaceSolver& operator=(
-            const L1ExactPenaltyRestoPDFSpaceSolver&
-            );
+    // Gosh.
 
     SmartPtr<AugSystemSolver> augSysSolver_;
     SmartPtr<PDPerturbationHandler> perturbHandler_;

--- a/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyRestoPdfSpaceSolver.hpp
+++ b/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyRestoPdfSpaceSolver.hpp
@@ -1,6 +1,6 @@
 //
-// Created by David on 12/29/2020.
-//
+// Created by David Thierry on 12/29/2020.
+// We need comments here.
 
 #ifndef SRC_IPL1EXACTPENALTYRESTOPDFSPACESOLVER_HPP
 #define SRC_IPL1EXACTPENALTYRESTOPDFSPACESOLVER_HPP
@@ -38,8 +38,10 @@ public:
             const SmartPtr<RegisteredOptions>& roptions
             );
 
+    L1ExactPenaltyRestoPDFSpaceSolver() = delete;
+    L1ExactPenaltyRestoPDFSpaceSolver(const L1ExactPenaltyRestoPDFSpaceSolver&) = delete;
+    L1ExactPenaltyRestoPDFSpaceSolver& operator =(const L1ExactPenaltyRestoPDFSpaceSolver&) = delete;
 private:
-    L1ExactPenaltyRestoPDFSpaceSolver();
 
     L1ExactPenaltyRestoPDFSpaceSolver& operator=(
             const L1ExactPenaltyRestoPDFSpaceSolver&

--- a/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyRhoUpdater.cpp
+++ b/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyRhoUpdater.cpp
@@ -277,6 +277,9 @@ bool L1ExactPenaltyRhoUpdater::UpdateRhoTrial() {
     if (old_rho < trial_rho)
     {
         new_rho = trial_rho + 1.;
+        new_rho = new_rho < l1_epr_max_rho * 10. ? new_rho : l1_epr_max_rho * 10.; // Put a maximum value on this x10 times.
+
+
         IpData().Append_info_string(" rhoT");
     }
     else if (!l1_epr_suff_feasib_update_ && old_rho < l1_epr_max_rho)

--- a/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyRhoUpdater.hpp
+++ b/src/contrib/L1ExactPenaltyResto/IpL1ExactPenaltyRhoUpdater.hpp
@@ -1,6 +1,6 @@
 //
 // Created by David on 1/9/2021.
-//
+// We need some comments here.
 
 #ifndef SRC_IPL1EXACTPENALTYRHOUPDATER_HPP
 #define SRC_IPL1EXACTPENALTYRHOUPDATER_HPP

--- a/src/contrib/L1ExactPenaltyResto/IpL1IpoptAlg.cpp
+++ b/src/contrib/L1ExactPenaltyResto/IpL1IpoptAlg.cpp
@@ -286,7 +286,7 @@ SolverReturn L1IpoptAlg::Optimize(bool isResto)
     {
         exc.ReportException(Jnlst(), J_MOREDETAILED);
         IpData().TimingStats().ComputeAcceptableTrialPoint().EndIfStarted();
-        retval = MAXITER_EXCEEDED;
+        retval = RESTORATION_FAILURE;
     }
     catch (RESTORATION_MAXITER_EXCEEDED& exc)
     {

--- a/src/contrib/L1ExactPenaltyResto/IpL1IpoptAlg.cpp
+++ b/src/contrib/L1ExactPenaltyResto/IpL1IpoptAlg.cpp
@@ -388,7 +388,7 @@ void L1IpoptAlg::AcceptTrialPoint()
                        "Line search didn't find acceptable trial point.\n");
         return;
     }
-
+    // Long awaited bug-fixes
     Index adjusted_slacks = IpCq().AdjustedTrialSlacks();
     DBG_PRINT((1, "adjusted_slack = %d\n", adjusted_slack));
     if(adjusted_slacks > 0)

--- a/src/contrib/L1ExactPenaltyResto/IpL1IpoptAlg.hpp
+++ b/src/contrib/L1ExactPenaltyResto/IpL1IpoptAlg.hpp
@@ -1,6 +1,6 @@
 //
-// Created by David on 1/6/2021.
-//
+// Created by David Thierry on 1/6/2021.
+// We need to add some comments
 
 #ifndef SRC_IPL1IPOPTALG_HPP
 #define SRC_IPL1IPOPTALG_HPP

--- a/src/contrib/L1ExactPenaltyResto/IpL1IpoptAlg.hpp
+++ b/src/contrib/L1ExactPenaltyResto/IpL1IpoptAlg.hpp
@@ -48,9 +48,7 @@ public:
             bool isResto = false
             );
 
-    static void RegisterOptions(
-            SmartPtr<RegisteredOptions> roptions
-            );
+
 
     L1IpoptAlg() = delete;
     L1IpoptAlg& operator =(const L1IpoptAlg&) = delete;

--- a/src/contrib/L1ExactPenaltyResto/IpRestoL1ExactPenalty.cpp
+++ b/src/contrib/L1ExactPenaltyResto/IpRestoL1ExactPenalty.cpp
@@ -119,7 +119,7 @@ bool L1ExactPenaltyRestorationPhase::PerformRestoration()
                            "Original primal inf is less than the tolerance.");
             //THROW_EXCEPTION(RESTORATION_CONVERGED_TO_FEASIBLE_POINT,
             //                "Restoration phase converged to a point with small primal infeasibility");
-            //retval = 0;
+            retval = 0;
         }
         else
         {
@@ -166,8 +166,14 @@ bool L1ExactPenaltyRestorationPhase::PerformRestoration()
 
         SmartPtr<const Vector> l1_curr_s = l1_ip_data->curr()->s();
         SmartPtr<const CompoundVector> cs = dynamic_cast<const CompoundVector*>(GetRawPtr(l1_curr_s));
-
-        SmartPtr<IteratesVector> trial = IpData().trial()->MakeNewContainer();
+        SmartPtr<const IteratesVector> itVec;
+        if(!IsValid(IpData().trial())){
+            itVec = IpData().curr();
+        }
+        else{
+            itVec = IpData().trial();
+        }
+        SmartPtr<IteratesVector> trial = itVec->MakeNewContainer();
         trial->Set_primal(*cx->GetComp(0), *cs->GetComp(0));
         IpData().set_trial(trial);
 

--- a/src/contrib/L1ExactPenaltyResto/IpRestoL1ExactPenalty.cpp
+++ b/src/contrib/L1ExactPenaltyResto/IpRestoL1ExactPenalty.cpp
@@ -151,6 +151,13 @@ bool L1ExactPenaltyRestorationPhase::PerformRestoration()
     {
         THROW_EXCEPTION(RESTORATION_USER_STOP, "User requested stop during restoration phase.");
     }
+    else if (l1_status == DIVERGING_ITERATES)
+    {
+        Jnlst().Printf(J_ERROR, J_MAIN,
+                       "Iterates are diverging; the value of the penalty parameter might be too high.\n "
+                       );
+        retval = 1;
+    }
     else
     {
         Jnlst().Printf(J_ERROR, J_MAIN,
@@ -167,6 +174,7 @@ bool L1ExactPenaltyRestorationPhase::PerformRestoration()
         SmartPtr<const Vector> l1_curr_s = l1_ip_data->curr()->s();
         SmartPtr<const CompoundVector> cs = dynamic_cast<const CompoundVector*>(GetRawPtr(l1_curr_s));
         SmartPtr<const IteratesVector> itVec;
+        // l1_status not SUCCEEDING but accepting STOP_AT_ACCEPTABLE_POINT requires a new IteratesVector
         if(!IsValid(IpData().trial())){
             itVec = IpData().curr();
         }

--- a/src/contrib/L1ExactPenaltyResto/IpRestoL1ExactPenalty.hpp
+++ b/src/contrib/L1ExactPenaltyResto/IpRestoL1ExactPenalty.hpp
@@ -1,6 +1,6 @@
 //
 // Created by David on 1/14/2021.
-//
+// We need some comments.
 
 #ifndef SRC_IPRESTOL1EXACTPENALTY_HPP
 #define SRC_IPRESTOL1EXACTPENALTY_HPP
@@ -25,15 +25,17 @@ public:
 
     static void RegisterOptions(SmartPtr<RegisteredOptions> roptions);
 
+    L1ExactPenaltyRestorationPhase() = delete;
+
+    L1ExactPenaltyRestorationPhase(const L1ExactPenaltyRestorationPhase&) = delete;
+
+    L1ExactPenaltyRestorationPhase& operator=(const L1ExactPenaltyRestorationPhase&) = delete;
+
 protected:
     bool PerformRestoration() override;
 
 private:
-    L1ExactPenaltyRestorationPhase();
 
-    L1ExactPenaltyRestorationPhase(const L1ExactPenaltyRestorationPhase&);
-
-    void operator=(const L1ExactPenaltyRestorationPhase&);
 
     SmartPtr<L1IpoptAlg> resto_alg_;
     SmartPtr<EqMultiplierCalculator> eq_mult_calculator_;


### PR DESCRIPTION
I added an option to the continue search in the event of having low inf_pr. 
But it is also limited to 5 times occurrence.
It worked in most cases.